### PR TITLE
refactor: 用 @Published 状态驱动设置页导航，替代 PassthroughSubject

### DIFF
--- a/PasteDirect.xcodeproj/project.pbxproj
+++ b/PasteDirect.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		CB0AB0022F10A00000ABOUT2 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0AB0012F10A00000ABOUT1 /* AboutView.swift */; };
 		CB2CDF002924E8D900E81836 /* PasteDirectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2CDEFF2924E8D900E81836 /* PasteDirectTests.swift */; };
 		CB2CDF0A2924E8D900E81836 /* PasteDirectUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2CDF092924E8D900E81836 /* PasteDirectUITests.swift */; };
 		CB2CDF0C2924E8D900E81836 /* PasteDirectUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2CDF0B2924E8D900E81836 /* PasteDirectUITestsLaunchTests.swift */; };
@@ -98,6 +99,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		CB0AB0012F10A00000ABOUT1 /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
 		CB2CDEEA2924E8D500E81836 /* PasteDirect.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PasteDirect.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB2CDEFB2924E8D900E81836 /* PasteDirectTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PasteDirectTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB2CDEFF2924E8D900E81836 /* PasteDirectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteDirectTests.swift; sourceTree = "<group>"; };
@@ -320,6 +322,7 @@
 		CBD1CAA72F87B2A6003ACBD7 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				CBD1CAAA2F87B2A6003ACBD7 /* SettingsModels.swift */,
 				CBD1CAA52F87B2A6003ACBD7 /* IgnoredAppsManager.swift */,
 				CBD1CAA62F87B2A6003ACBD7 /* SettingStore.swift */,
 			);
@@ -331,9 +334,9 @@
 			children = (
 				CBD1CAA82F87B2A6003ACBD7 /* DetailView.swift */,
 				CBD1CAA92F87B2A6003ACBD7 /* RulesDetailView.swift */,
-				CBD1CAAA2F87B2A6003ACBD7 /* SettingsModels.swift */,
 				CBD1CAAB2F87B2A6003ACBD7 /* SettingsView.swift */,
 				CBD1CAAC2F87B2A6003ACBD7 /* SidebarView.swift */,
+				CB0AB0012F10A00000ABOUT1 /* AboutView.swift */,
 			);
 			path = SwiftUI;
 			sourceTree = "<group>";
@@ -574,6 +577,7 @@
 				CBD1CACF2F87B2A6003ACBD7 /* NSAttributeString+Extension.swift in Sources */,
 				CBD1CAD02F87B2A6003ACBD7 /* HexColorValidator.swift in Sources */,
 				CBD1CAD12F87B2A6003ACBD7 /* SidebarView.swift in Sources */,
+				CB0AB0022F10A00000ABOUT2 /* AboutView.swift in Sources */,
 				CBD1CAD22F87B2A6003ACBD7 /* PasteboardModel.swift in Sources */,
 				CBD1CAD32F87B2A6003ACBD7 /* Then.swift in Sources */,
 				CBD1CAD42F87B2A6003ACBD7 /* PasteSQLManager.swift in Sources */,

--- a/PasteDirect/Resource/Localizable.xcstrings
+++ b/PasteDirect/Resource/Localizable.xcstrings
@@ -44,6 +44,39 @@
         }
       }
     },
+    "© 2022-2026 南山忆" : {
+
+    },
+    "A lightweight clipboard manager for macOS" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一款轻量级的 macOS 剪贴板管理工具"
+          }
+        }
+      }
+    },
+    "About" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关于"
+          }
+        }
+      }
+    },
+    "About PasteDirect" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关于 PasteDirect"
+          }
+        }
+      }
+    },
     "Always paste as plain text" : {
       "localizations" : {
         "zh-Hans" : {
@@ -228,6 +261,9 @@
         }
       }
     },
+    "GitHub" : {
+
+    },
     "Ignore application" : {
       "localizations" : {
         "zh-Hans" : {
@@ -389,6 +425,9 @@
           }
         }
       }
+    },
+    "PasteDirect" : {
+
     },
     "PasteDirect requires accessibility permissions" : {
       "localizations" : {
@@ -586,6 +625,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未知"
+          }
+        }
+      }
+    },
+    "Version %@" : {
+      "comment" : "App version display",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "版本 %@"
           }
         }
       }

--- a/PasteDirect/Source/App/AppCoordinator.swift
+++ b/PasteDirect/Source/App/AppCoordinator.swift
@@ -12,12 +12,13 @@ protocol AppCoordinator: AnyObject {
     var frontAppName: String? { get }
     func activateFrontApp()
     func dismissWindow(_ completionHandler: (() -> Void)?)
-    func showSettings()
+    func showSettings(category: SettingCategory?)
     func setStatusItemVisible(_ isVisible: Bool)
 }
 
 extension AppCoordinator {
     func dismissWindow() { dismissWindow(nil) }
+    func showSettings() { showSettings(category: nil) }
 }
 
 enum AppContext {

--- a/PasteDirect/Source/App/PasteAppDelegate.swift
+++ b/PasteDirect/Source/App/PasteAppDelegate.swift
@@ -14,6 +14,10 @@ import KeyboardShortcuts
 final class PasteAppDelegate: NSObject {
     private let menuBarItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     private lazy var rMenu = NSMenu(title: "").then {
+        let aboutItem = NSMenuItem(title: String(localized: "About PasteDirect"), action: #selector(aboutAction), keyEquivalent: "")
+        aboutItem.image = NSImage(systemSymbolName: "info.circle", accessibilityDescription: nil)
+        $0.addItem(aboutItem)
+        $0.addItem(NSMenuItem.separator())
         let item1 = NSMenuItem(title: String(localized: "Settings..."), action: #selector(settingsAction), keyEquivalent: ",")
         item1.image = NSImage(systemSymbolName: "gearshape", accessibilityDescription: nil)
         $0.addItem(item1)
@@ -133,6 +137,11 @@ extension PasteAppDelegate {
     private func settingsAction() {
         showSettings()
     }
+
+    @objc
+    private func aboutAction() {
+        showSettings(category: .about)
+    }
 }
 
 // MARK: - AppCoordinator
@@ -150,8 +159,8 @@ extension PasteAppDelegate: AppCoordinator {
         mainWindowController.dismissWindow(completionHandler)
     }
 
-    func showSettings() {
-        settingsWindowController.show()
+    func showSettings(category: SettingCategory? = nil) {
+        settingsWindowController.show(category: category)
     }
 
     func setStatusItemVisible(_ isVisible: Bool) {

--- a/PasteDirect/Source/Main/View/PasteSearchField.swift
+++ b/PasteDirect/Source/Main/View/PasteSearchField.swift
@@ -115,12 +115,19 @@ final class PasteSearchField: NSSearchField {
         let tagsWidth = tags.isEmpty ? 0 : tagContainer.frame.width + 2
         customCell?.extraLeadingOffset = tagsWidth
 
-        // 强制 field editor 重新布局
-        if let editor = currentEditor() as? NSTextView {
-            editor.frame = customCell?.searchTextRect(forBounds: bounds) ?? bounds
-            editor.needsDisplay = true
-        }
+        needsLayout = true
         needsDisplay = true
+    }
+
+    override func layout() {
+        super.layout()
+        if let editor = currentEditor() as? NSTextView {
+            let textRect = customCell?.searchTextRect(forBounds: bounds) ?? bounds
+            if editor.frame != textRect {
+                editor.frame = textRect
+                editor.needsDisplay = true
+            }
+        }
     }
 
     override var stringValue: String {

--- a/PasteDirect/Source/Setting/Controller/PasteSettingWindowController.swift
+++ b/PasteDirect/Source/Setting/Controller/PasteSettingWindowController.swift
@@ -9,16 +9,20 @@ import Cocoa
 import SwiftUI
 
 class PasteSettingWindowController: NSWindowController {
-    private let hostingController = NSHostingController(rootView: SettingsView()).then {
+    private let settingsViewModel = SettingsNavigationModel()
+
+    private lazy var hostingController = NSHostingController(
+        rootView: SettingsView(navigationModel: settingsViewModel)
+    ).then {
         $0.sizingOptions = [.preferredContentSize]
     }
-    
+
     init() {
         let window = NSWindow(contentRect: .zero, styleMask: [.titled, .closable, .fullSizeContentView], backing: .buffered, defer: false)
         window.titleVisibility = .visible
         window.titlebarSeparatorStyle = .automatic
-        window.contentViewController = hostingController
         super.init(window: window)
+        window.contentViewController = hostingController
         showWindow(self)
     }
 
@@ -27,7 +31,7 @@ class PasteSettingWindowController: NSWindowController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    public func show() {
+    public func show(category: SettingCategory? = nil) {
         Task { await PasteDataStore.main.updateStorageSize() }
         if #available(macOS 14, *) {
             NSApp.activate()
@@ -36,5 +40,8 @@ class PasteSettingWindowController: NSWindowController {
         }
         showWindow(self)
         window?.center()
+        if let category {
+            settingsViewModel.selectedCategory = category
+        }
     }
 }

--- a/PasteDirect/Source/Setting/Model/SettingsModels.swift
+++ b/PasteDirect/Source/Setting/Model/SettingsModels.swift
@@ -6,6 +6,7 @@ import SwiftUI
 enum SettingContentType {
     case common
     case custom
+    case about
 }
 
 struct SettingCategory: Identifiable, Hashable {
@@ -54,7 +55,14 @@ struct SettingCategory: Identifiable, Hashable {
         sections: []
     )
 
-    @MainActor static let allCategories = [general, shortcuts, ignore]
+    @MainActor static let about = SettingCategory(
+        type: .about,
+        title: "About",
+        icon: "info.circle",
+        sections: []
+    )
+
+    @MainActor static let allCategories = [general, shortcuts, ignore, about]
 
     static func == (lhs: SettingCategory, rhs: SettingCategory) -> Bool {
         return lhs.id == rhs.id

--- a/PasteDirect/Source/Setting/SwiftUI/AboutView.swift
+++ b/PasteDirect/Source/Setting/SwiftUI/AboutView.swift
@@ -1,0 +1,70 @@
+//
+//  AboutView.swift
+//  PasteDirect
+//
+//  Created by 南山忆 on 2026/04/29.
+//
+
+import SwiftUI
+
+struct AboutView: View {
+    private let appVersion: String = {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
+        return "\(version)"
+    }()
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            appIconView
+
+            VStack(spacing: 6) {
+                Text("PasteDirect")
+                    .font(.system(size: 22, weight: .semibold))
+
+                Text("Version \(appVersion)", comment: "App version display")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+            }
+
+            Text("A lightweight clipboard manager for macOS")
+                .font(.system(size: 13))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            VStack(spacing: 12) {
+                Link(destination: URL(string: "https://github.com/nanshanyi/PasteDirect")!) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "link")
+                        Text("GitHub")
+                    }
+                    .font(.system(size: 13))
+                }
+
+                Text("© 2022-2026 南山忆")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.tertiary)
+            }
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .navigationTitle("About")
+    }
+
+    private var appIconView: some View {
+        Group {
+            if let appIcon = NSApp.applicationIconImage {
+                Image(nsImage: appIcon)
+                    .resizable()
+                    .frame(width: 96, height: 96)
+            } else {
+                Image(systemName: "doc.on.clipboard")
+                    .font(.system(size: 48))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 96, height: 96)
+            }
+        }
+    }
+}

--- a/PasteDirect/Source/Setting/SwiftUI/DetailView.swift
+++ b/PasteDirect/Source/Setting/SwiftUI/DetailView.swift
@@ -14,6 +14,8 @@ struct DetailView: View {
                     commonCategoryView(category)
                 case .custom:
                     RulesDetailView(category: category)
+                case .about:
+                    AboutView()
                 }
             } else {
                 emptyView

--- a/PasteDirect/Source/Setting/SwiftUI/SettingsView.swift
+++ b/PasteDirect/Source/Setting/SwiftUI/SettingsView.swift
@@ -1,16 +1,23 @@
 import SwiftUI
 
+// MARK: - Navigation Model
+
+@MainActor
+final class SettingsNavigationModel: ObservableObject {
+    @Published var selectedCategory: SettingCategory? = SettingCategory.general
+}
+
 // MARK: - Main Settings View
 
 struct SettingsView: View {
     @StateObject private var settingsStore = SettingsStore.shared
-    @State private var selectedCategory: SettingCategory? = SettingCategory.general
+    @ObservedObject var navigationModel: SettingsNavigationModel
 
     var body: some View {
         NavigationSplitView {
-            SidebarView(selectedCategory: $selectedCategory)
+            SidebarView(selectedCategory: $navigationModel.selectedCategory)
         } detail: {
-            DetailView(category: selectedCategory)
+            DetailView(category: navigationModel.selectedCategory)
         }
         .navigationSplitViewStyle(.prominentDetail)
         .environmentObject(settingsStore)


### PR DESCRIPTION
将 selectedCategory 提升到 SettingsNavigationModel，消除事件时序问题； show(selectAbout:) 改为 show(category:) 支持跳转任意设置页面。